### PR TITLE
Separate removal of NA and out-of-range values

### DIFF
--- a/R/concept-load.R
+++ b/R/concept-load.R
@@ -308,17 +308,21 @@ filter_bounds <- function(x, col, min, max) {
 
     nna & op(vc, val)
   }
+  
+  # Remove missing values
+  n_total <- nrow(x)
+  x <- rm_na_val_var(x)
 
+  # Remove out of range 
+  n_nonmis <- nrow(x)
   keep  <- check_bound(x[[col]], min, `>=`) & check_bound(x[[col]], max, `<=`)
-  n_row <- nrow(x)
-
   x <- x[keep, ]
 
-  n_rm <- n_row - nrow(x)
+  n_rm <- n_nonmis - nrow(x)
 
   if (n_rm > 0L) {
-    msg_progress("removed {n_rm} ({prcnt(n_rm, n_row)}) of rows due to out
-                  of range (or `NA`) entries")
+    msg_progress("removed {n_rm} ({prcnt(n_rm, n_total)}) of rows due to out
+                  of range entries")
   }
 
   x


### PR DESCRIPTION
### Problem
`ricu` currently provides a joint warning when out-of-range values or `NA` are removed during loading of a concept. For example, when loading `temp` (body temperature) in the eICU demo we obtain the following message:

```r
library(ricu)
res <- load_concepts("temp", src = "eicu_demo")
#> -- Loading 1 concept -----------------------------------------------------------------------------------------------------------
#> * temp                                                                                                                        
#>   ( ) removed 1525347 (93.3%) of rows due to out of range (or `NA`) entries
#> --------------------------------------------------------------------------------------------------------------------------------

```

The current behaviour makes it hard to judge whether the rows were primarily removed because of missing values or because of out-of-range values. While missing values may indicate a sparsely filled matrix (as is the case here), many out-of-range values may instead suggest unit conversion errors. Currently, one needs to delve into concept definitions and source tables to identify which ones the cause. 

### Proposed solution
Separating these cases into distinct messages may make it clearer on a first glance why rows were excluded. While this adds an extra row to the output of a (verbose) `load_concept` call, I believe it would be worth it for clarity. The result for the above example is: 

```r
library(ricu)
res <- load_concepts("temp", src = "eicu_demo")
#> -- Loading 1 concept -----------------------------------------------------------------------------------------------------------
#> * temp                                                                                                                        
#>   ( ) removed 1522140 (93.1%) of rows due to `NA` values
#>   ( ) removed 3207 (0.2%) of rows due to out of range entries
#> --------------------------------------------------------------------------------------------------------------------------------
```

### Note
This currently merges into `main`, as it seems to be the most up-to-date. Please let me know if you'd like me to merge into `dev` or another branch instead. 