### PR TITLE
Remove skin temperature from miiv::temp

### DIFF
--- a/inst/extdata/config/concept-dict.json
+++ b/inst/extdata/config/concept-dict.json
@@ -5408,7 +5408,7 @@
           "sub_var": "itemid"
         },
         {
-          "ids": [223761, 224027],
+          "ids": 223761,
           "table": "chartevents",
           "sub_var": "itemid",
           "callback": "convert_unit(fahr_to_cels, 'C', 'f')"


### PR DESCRIPTION
### Problem 

Item `224027 ` (=skin temperature assessment) resulted in many `NA`s when calculating the `temp` concept for MIMIC IV. See #4 for more details.

### Solution

Remove this item from the concept definition for `temp`.