### PR TITLE
Load rec args

### DIFF
--- a/R/callback-cncpt.R
+++ b/R/callback-cncpt.R
@@ -5,36 +5,10 @@ collect_dots <- function(concepts, interval, ..., merge_dat = FALSE) {
 
   dots <- list(...)
 
-  if (length(concepts) == 1L) {
-
-    assert_that(identical(length(dots), 1L))
-
-    res <- dots[[1L]]
-
-    if (is_ts_tbl(res)) {
-      ival <- coalesce(interval, interval(res))
-      assert_that(has_interval(res, ival))
-    } else {
-      assert_that(is_df(res))
-    }
-
-    return(res)
-  }
-
-  if (length(dots) == 1L) {
-    dots <- dots[[1L]]
-  }
-
-  if (is.null(names(dots))) {
-    names(dots) <- concepts
-  }
-
   if (not_null(names(concepts))) {
     concepts <- chr_ply(concepts, grep, names(dots), value = TRUE,
                         use_names = TRUE)
   }
-
-  assert_that(setequal(names(dots), concepts))
 
   res <- dots[concepts]
 
@@ -46,7 +20,9 @@ collect_dots <- function(concepts, interval, ..., merge_dat = FALSE) {
 
   ival <- check_interval(res, interval)
 
-  if (merge_dat) {
+  if (length(res) == 1) {
+    res <- res[[1]]
+  } else if (merge_dat) {
     res <- reduce(merge, res, all = TRUE)
   } else {
     attr(res, "ival_checked") <- ival

--- a/R/concept-load.R
+++ b/R/concept-load.R
@@ -495,7 +495,7 @@ load_concepts.rec_cncpt <- function(x, aggregate = NULL, patient_ids = NULL,
 
   ext <- list(patient_ids = patient_ids, id_type = id_type,
               interval = coalesce(x[["interval"]], interval),
-              progress = progress)
+              ..., progress = progress)
 
   sub <- x[["items"]]
   agg <- x[["aggregate"]]
@@ -553,8 +553,6 @@ load_concepts.item <- function(x, patient_ids = NULL, id_type = "icustay",
 #' @export
 load_concepts.itm <- function(x, patient_ids = NULL, id_type = "icustay",
                               interval = hours(1L), ...) {
-
-  warn_dots(..., ok_args = "keep_components")
 
   res <- do_itm_load(x, id_type, interval = interval)
   res <- merge_patid(res, patient_ids)

--- a/tests/testthat/test-callback.R
+++ b/tests/testthat/test-callback.R
@@ -269,5 +269,5 @@ test_that("susp_inf", {
     57, 61, 70)), susp_inf = rep(TRUE, 6L), interval = hours(1L)
   )
 
-  expect_identical(susp_inf(abx, samp), expected)
+  expect_identical(susp_inf(abx = abx, samp = samp), expected)
 })

--- a/tests/testthat/test-scores.R
+++ b/tests/testthat/test-scores.R
@@ -43,7 +43,7 @@ test_that("suspicion of infection", {
   expect_equal(interval(si_ei), hours(1L))
 })
 
-sep3 <- sep3(so_mi, si_mi)
+sep3 <- sep3(sofa = so_mi, susp_inf = si_mi)
 
 test_that("sepsis 3", {
 


### PR DESCRIPTION
See #18 for a detailed description of the issues addressed in this PR.

### Description of changes

This PR adds the ability to pass arguments to lower-level concepts in recursive concepts. In order to do so, this PR does two things:

1. It allows `collect_dots` to deal with (=ignore) arguments in `...` that are not concepts. The trade-off is that `collect_dots` can now only deal with named concepts. However, this does not seem to be a huge problem, since except for two tests (that I changed), all functions pass their concepts with corresponding names. 
2. In `load_concepts.rec_cncpt`, it passes `...` on to `load_concepts.itm` (via `load_one_concept_helper`). 

### Note
`load_concepts.itm` currently checks for elements in `...` that aren't `keep_components` and throws an error if they are present. This behaviour has been removed in this PR to silence unnecessary warnings. However, there might be a good reason for having the warning there and perhaps a different solution must be found. 