### PR TITLE
Allow levels to be missing for `fct_concept`

### DIFF
--- a/R/concept-load.R
+++ b/R/concept-load.R
@@ -491,6 +491,8 @@ load_concepts.fct_cncpt <- function(x, aggregate = NULL, ...,
     res  <- set(res, j = "val_var", value = character())
   } else if (is.character(lvl)) {
     keep <- res[["val_var"]] %chin% lvl
+  } else if (is.null(lvl)) {
+    keep <- TRUE
   } else {
     keep <- res[["val_var"]] %in% lvl
   }

--- a/R/concept-utils.R
+++ b/R/concept-utils.R
@@ -1007,11 +1007,11 @@ init_cncpt.unt_cncpt <- function(x, unit = NULL, min = NULL, max = NULL, ...) {
 #'
 #' @rdname data_concepts
 #' @export
-init_cncpt.fct_cncpt <- function(x, levels, ...) {
+init_cncpt.fct_cncpt <- function(x, levels = NULL, ...) {
 
   warn_dots(...)
 
-  assert_that(is.atomic(levels), has_length(levels),
+  assert_that(null_or(levels, is.atomic), null_or(levels, has_length),
               null_or(x[["aggregate"]], is.string))
 
   x[["levels"]] <- levels


### PR DESCRIPTION
The [docs](https://github.com/eth-mds/ricu/blob/f6a7c3687e00730336c2d9986891673c4c74eea0/R/concept-utils.R#L867) state

> #' * `fct_cncpt`: In case of categorical concepts, such as `sex`, a set of
#'   factor levels can be specified, against which the loaded data is checked.

Currently, a set of factor levels *needs* to be specified. Sometimes this is not desirable. This PR allows not specifying `levels` in `fct_cncpt`.