### PR TITLE
Update data-sources.json: `caregiver.csv.gz` in `miiv`

### DIFF
--- a/inst/extdata/config/data-sources.json
+++ b/inst/extdata/config/data-sources.json
@@ -8681,7 +8681,7 @@
         }
       },
       "caregiver": {
-        "files": "hosp/caregiver.csv.gz",
+        "files": "icu/caregiver.csv.gz",
         "defaults": [],
         "num_rows": 15468,
         "cols": {


### PR DESCRIPTION
I think the source path for the `caregiver.csv.gz` in `miiv` needs a fix.

According to the downloaded data layout of `miiv` in version 2.2 it should be in `icu/caregiver.csv.gz` but the config file refers to `hosp`.

See data layout here: https://physionet.org/content/mimiciv/2.2/icu/#files-panel