### PR TITLE
Fix limits in `urine24` by not using `win_tbl`

### DIFF
--- a/R/callback-cncpt.R
+++ b/R/callback-cncpt.R
@@ -468,7 +468,8 @@ urine24 <- function(..., min_win = hours(12L), limits = NULL,
   step_factor <- convert_dt(hours(24L)) / as.double(interval)
 
   if (is.null(limits)) {
-    limits <- collapse(res)
+    limits <- collapse(res, as_win_tbl = FALSE) 
+    limits <- as_ts_tbl(limits, index_var = "start", interval = interval(res))
   }
 
   res <- fill_gaps(res, limits = limits)


### PR DESCRIPTION
Fixes the issue described in #61. 

Note that we could alternatively fix how `fill_gaps` handles `win_tbl`s but this would be a bigger change with potentially unintended consequences. This change simply fixes the issue locally in `urine24` and therefore only affects downstream code that relies on this concept. 